### PR TITLE
プロフィール画面の仮UI作成

### DIFF
--- a/lib/view/profile/children/profile_edit_button.dart
+++ b/lib/view/profile/children/profile_edit_button.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class ProfileEditButton extends StatelessWidget {
+  const ProfileEditButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () => null,
+      child: const Center(
+        child: Text('プロフィールを編集'),
+      ),
+      style: ElevatedButton.styleFrom(
+        primary: Colors.black38,
+        elevation: 0,
+      ),
+    );
+  }
+}

--- a/lib/view/profile/children/profile_grid_view.dart
+++ b/lib/view/profile/children/profile_grid_view.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class ProfileGridView extends StatelessWidget {
+  const ProfileGridView({Key? key}) : super(key: key);
+
+  //TODO 投稿画像をFirebaseから取ってくる
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      gridDelegate:
+          const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+      itemCount: 12,
+      itemBuilder: (context, index) {
+        return Image.asset('assets/images/user.jpeg');
+      },
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+    );
+  }
+}

--- a/lib/view/profile/children/profile_status.dart
+++ b/lib/view/profile/children/profile_status.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class ProfileStatus extends StatelessWidget {
+  const ProfileStatus({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      //TODO Firebaseから取ってくる
+      children: [
+        const CircleAvatar(
+          backgroundImage: AssetImage('assets/images/user.jpeg'),
+          maxRadius: 35,
+        ),
+        Column(
+          children: const [
+            Text('12'),
+            Text('投稿'),
+          ],
+        ),
+        Column(
+          children: const [
+            Text('289'),
+            Text('フォロー'),
+          ],
+        ),
+        Column(
+          children: const [
+            Text('249'),
+            Text('フォロワー'),
+          ],
+        ),
+        Column(
+          children: const [
+            Text('3'),
+            Text('趣味'),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/profile/profile_screen.dart
+++ b/lib/view/profile/profile_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shumeet/view/profile/children/profile_edit_button.dart';
+import 'package:shumeet/view/profile/children/profile_grid_view.dart';
 import 'package:shumeet/view/profile/children/profile_status.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -7,29 +8,34 @@ class ProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: const [
-        SizedBox(height: 45),
-        Padding(
-          padding: EdgeInsets.only(left: 16.0),
-          child: Text(
-            'はちみつぼーい',
-            style: TextStyle(fontSize: 20),
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          SizedBox(height: 45),
+          Padding(
+            padding: EdgeInsets.only(left: 16.0),
+            child: Text(
+              'はちみつぼーい',
+              style: TextStyle(fontSize: 20),
+            ),
           ),
-        ),
-        SizedBox(height: 15),
-        ProfileStatus(),
-        SizedBox(height: 10),
-        Padding(
-          padding: EdgeInsets.only(left: 16.0),
-          child: Text('はちみつ大好き23歳'),
-        ),
-        Padding(
-          padding: EdgeInsets.all(16.0),
-          child: ProfileEditButton(),
-        ),
-      ],
+          SizedBox(height: 15),
+          ProfileStatus(),
+          SizedBox(height: 10),
+          Padding(
+            padding: EdgeInsets.only(left: 16.0),
+            child: Text('はちみつ大好き23歳'),
+          ),
+          SizedBox(height: 10),
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16.0),
+            child: ProfileEditButton(),
+          ),
+          SizedBox(height: 5),
+          ProfileGridView(),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/profile/profile_screen.dart
+++ b/lib/view/profile/profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shumeet/view/profile/children/profile_edit_button.dart';
 import 'package:shumeet/view/profile/children/profile_status.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -19,6 +20,15 @@ class ProfileScreen extends StatelessWidget {
         ),
         SizedBox(height: 15),
         ProfileStatus(),
+        SizedBox(height: 10),
+        Padding(
+          padding: EdgeInsets.only(left: 16.0),
+          child: Text('はちみつ大好き23歳'),
+        ),
+        Padding(
+          padding: EdgeInsets.all(16.0),
+          child: ProfileEditButton(),
+        ),
       ],
     );
   }

--- a/lib/view/profile/profile_screen.dart
+++ b/lib/view/profile/profile_screen.dart
@@ -1,12 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:shumeet/view/profile/children/profile_status.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('プロフィール画面'),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: const [
+        SizedBox(height: 45),
+        Padding(
+          padding: EdgeInsets.only(left: 16.0),
+          child: Text(
+            'はちみつぼーい',
+            style: TextStyle(fontSize: 20),
+          ),
+        ),
+        SizedBox(height: 15),
+        ProfileStatus(),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 内容
shumeetのプロフィール画面の仮UIの作成

## 概要
- プロフィール画像、投稿数、フォロー数、フォロワー数、趣味数を表示するProfileStatusWidgetの作成
- プロフィール編集に入るボタンの作成
- 投稿内容を表示するProfileGridViewの作成

## 実装できていない部分
- Firebaseとの繋ぎこみ

## スクリーンショット


![Simulator Screen Shot - iPhone 13 - 2022-12-04 at 18 27 03-2](https://user-images.githubusercontent.com/39763423/205484645-6a8dc019-ef7c-4f2e-92b3-cb3c3a436be0.png)

